### PR TITLE
DEVOPS-4197: reload handler and testing updates

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,18 +62,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     
   end
 
-  config.vm.define 'ubuntu-precise' do |ubuntu_p|
-    ubuntu_p.vm.box      = 'ubuntu/precise64'
-    ubuntu_p.vm.hostname = 'ubuntu-precise'
+  config.vm.define 'ubuntu-focal' do |ubuntu_f|
+    ubuntu_f.vm.box      = 'ubuntu/focal64'
+    ubuntu_f.vm.hostname = 'ubuntu-focal'
     
-    ubuntu_p.vm.provision 'shell', inline: 'apt-get update'
-    ubuntu_p.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
-    ubuntu_p.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
-    ubuntu_p.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
+    ubuntu_f.vm.provision 'shell', inline: 'apt-get update'
+    ubuntu_f.vm.provision 'shell', inline: 'apt-get install -y -qq  python2 libffi-dev libssl-dev python2-dev gcc'
+    ubuntu_f.vm.provision 'shell', inline: 'curl -s https://bootstrap.pypa.io/pip/2.7/get-pip.py --output - | python2 -'
+    ubuntu_f.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
+    ubuntu_f.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
 
-    ubuntu_p.vm.provision 'ansible_local' do |ansible| 
+    ubuntu_f.vm.provision 'ansible_local' do |ansible|
       ansible.playbook = 'tests/test_vagrant.yml'
       ansible.extra_vars = {
+        :ansible_python_interpreter => "/usr/bin/python2"
       }
     end
     
@@ -85,9 +87,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     centos7.vm.provision 'shell', inline: 'yum install -y ca-certificates'
     centos7.vm.provision 'shell', inline: "echo \"#{EPEL_REPO_7}\" > /etc/yum.repos.d/epel.repo"
-    centos7.vm.provision 'shell', inline: 'yum install -y python-pip python-devel gcc libffi-devel openssl-devel'
+    centos7.vm.provision 'shell', inline: 'yum install -y python-devel gcc libffi-devel openssl-devel'
     centos7.vm.provision 'shell', inline: 'setenforce 0'
-    centos7.vm.provision 'shell', inline: "pip install -q pip --upgrade"
+    centos7.vm.provision 'shell', inline: "curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o - | python"
     centos7.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
     centos7.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
 
@@ -104,8 +106,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     centos6.vm.provision 'shell', inline: 'yum install -y ca-certificates'
     centos6.vm.provision 'shell', inline: "echo \"#{EPEL_REPO_6}\" > /etc/yum.repos.d/epel.repo"
-    centos6.vm.provision 'shell', inline: 'yum install -y python-pip python-devel gcc libffi-devel openssl-devel'
-    centos6.vm.provision 'shell', inline: "pip install -q pip --upgrade"
+    centos6.vm.provision 'shell', inline: 'yum install -y python2-pip python-devel gcc libffi-devel openssl-devel'
+    centos6.vm.provision 'shell', inline: "pip install -q pip==20.3.4 --upgrade"
     centos6.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
 
     centos6.vm.provision 'ansible_local' do |ansible| 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,14 +4,6 @@ ANSIBLE_VERSION = "2.3.0.0"
 
 ANSIBLE_ROLE = 'ansible-role-nginx'
 
-EPEL_REPO_6 = '''
-[epel]
-name     = EPEL 6 - \$basearch
-baseurl  = http://mirror.globo.com/epel/6/\$basearch
-enabled  = 1
-gpgcheck = 0
-'''
-
 EPEL_REPO_7 = '''
 [epel]
 name     = EPEL 7 - \$basearch
@@ -28,38 +20,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize [ 'modifyvm', :id, '--nictype1', 'virtio' ]
     vb.customize [ 'modifyvm', :id, '--natdnshostresolver1', 'on' ]
     vb.customize [ 'modifyvm', :id, '--natdnsproxy1', 'on' ]
-  end
-      
-  config.vm.define 'ubuntu-xenial' do |ubuntu_x|
-    ubuntu_x.vm.box      = 'ubuntu/xenial64'
-    #ubuntu_x.vm.hostname = 'ubuntu-xenial'
-    
-    ubuntu_x.vm.provision 'shell', inline: 'apt-get update'
-    ubuntu_x.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
-    ubuntu_x.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} jinja2"
-    ubuntu_x.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
-
-    ubuntu_x.vm.provision 'ansible_local' do |ansible| 
-      ansible.playbook = 'tests/test_vagrant.yml'
-    end
-    
-  end
-
-  config.vm.define 'ubuntu-trusty' do |ubuntu_t|
-    ubuntu_t.vm.box      = 'ubuntu/trusty64'
-    ubuntu_t.vm.hostname = 'ubuntu-trusty'
-    
-    ubuntu_t.vm.provision 'shell', inline: 'apt-get update'
-    ubuntu_t.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
-    ubuntu_t.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
-    ubuntu_t.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
-
-    ubuntu_t.vm.provision 'ansible_local' do |ansible| 
-      ansible.playbook = 'tests/test_vagrant.yml'
-      ansible.extra_vars = {
-      }
-    end
-    
   end
 
   config.vm.define 'ubuntu-focal' do |ubuntu_f|
@@ -95,23 +55,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     centos7.vm.provision 'ansible_local' do |ansible| 
       ansible.playbook = 'tests/test_vagrant.yml'
-      ansible.extra_vars = {
-      }
-    end
-  end
-
-  config.vm.define 'centos-6' do |centos6|
-    centos6.vm.box      = "puppetlabs/centos-6.6-64-nocm"
-    centos6.vm.hostname = 'centos-6'
-
-    centos6.vm.provision 'shell', inline: 'yum install -y ca-certificates'
-    centos6.vm.provision 'shell', inline: "echo \"#{EPEL_REPO_6}\" > /etc/yum.repos.d/epel.repo"
-    centos6.vm.provision 'shell', inline: 'yum install -y python2-pip python-devel gcc libffi-devel openssl-devel'
-    centos6.vm.provision 'shell', inline: "pip install -q pip==20.3.4 --upgrade"
-    centos6.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
-
-    centos6.vm.provision 'ansible_local' do |ansible| 
-      ansible.playbook   = 'tests/test_vagrant.yml'
       ansible.extra_vars = {
       }
     end

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,4 +9,7 @@
 - name: nginx restart
   service: name=nginx state=restarted
 
+- name: nginx reload
+  service: name=nginx state=reloaded
+
 # vi:ts=2:sw=2:et:ft=yaml

--- a/molecule/compiled/converge.yml
+++ b/molecule/compiled/converge.yml
@@ -1,0 +1,141 @@
+---
+- hosts: all
+  become: yes
+
+  vars:
+    # Ensure this is compiled
+    - nginx_install_compiled: true
+    - nginx_install_repo: false
+
+    - nginx_context_main: |
+        worker_rlimit_nofile 4096;
+        worker_processes 1;
+    - nginx_no_log: false
+    - nginx_log_symlink_src: /mnt/log/nginx
+    - nginx_disable_vhosts:
+        - default
+    - nginx_vhosts:
+        - server_name: foo.com
+          default_server: true
+          listen_parameters:
+            - deferred
+            - backlog=512
+          access_log: "{{nginx_log_dir}}/othervhosts.log"
+          logrotate_enabled: true
+          server_aliases:
+            - www.foo.bar
+            - baz.foo.bar
+          root: /var/www/foo.com/html
+          log_fmt: test
+
+        - server_name: sslfoo.com
+          server_aliases:
+            - www.sslfoo.bar
+          root: /var/www/sslfoo.com/html
+          ssl_enabled: true
+          certs:
+            key: |
+              -----BEGIN PRIVATE KEY-----
+              MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDE/xm+MDpvOSNw
+              IX9tATbB+qxisfWtcQgo20wIu4EJICJk3DJ56V8yMzG5a0x7SMmk1b2XMuls8FZv
+              Aj9NhtsNHW02iMMz8U/cy5H+8z+2dBLceHynkFse4KV7h7FqLDwKqsbXCCp5sO3c
+              suE43Jo2DVoCVNTDaUtCAMqelwIFHAvJVLT1OoaNiJD5T8G9r/IOgS0RCeWk0NvH
+              etnYtvwAvxtz+Y4tsSxAwLE+LgQtHdOpI/pdCa5P8SX37NHY/fbu95ESjYyMvybA
+              9TDqziUUx5V5iMDX9UYfOTI764S5aorjfy0Rt9fqlpnqmKRs1qXKosH0Zh555Bux
+              dTfi1cslAgMBAAECggEBAJBicNnGu219sY2j36NjOmEee26zBGAk8lgPs0DLPR4V
+              IWBPS+eytoUypIVEMYBCrxhTWGwTcqbX2GHwgbku2CpaoQtRXdEaUvB/e/gjDVWK
+              6bAR1ztxQHf3KxLJN62b0j33QVmlsIwUs6IIsa5dceGgE5KV3oODDxfHQLrP7zkS
+              NeRAiwf4KwdBL71Xka7/PN+DM6TtiIrZeSJTnE/1FjflTkG/noa6mHMS3z/fAMKP
+              9MctD5H+Qu/2LTDPofmH5kAQiV+CE2yGUHtIMvaUfxy7cl8/L9sQQzMPbdNhZQXP
+              LghYjAIFpnkf3nPr0WZtqXzrfGV5HWtO2H3ny4bkT8ECgYEA6Jvxx+L1rWltHMiR
+              7/lwGLA74DIzfQzme89+f+2g2fvImBWPf/aXrcoENHuSKmrTYbsijxQ7XKw+jZQu
+              BSuRKI1l+0jku6tm6l6+U8dKNjksqOJ5oiSklxbzXCj5m2rocAhGVTjkiq2jZ3Zw
+              OG9TCLQAsZ63Jd8Ue1obb/mk8z0CgYEA2M5hIOSsauLfT1FUgHonKcxFuyuZJI3i
+              nXkNkq4u97q8QqFgIWOd4nVwgeeSwUm2B/CpF/pQJxOPIwx+/WebxXsgA+VrMMxm
+              oYe4WXZnTeYMUhUdukpNCXJRJsfQIWYxEzzTEWnwwA3QRPhBQCMqx+9ZWdhzvorS
+              Kg2RGBXKFgkCgYEAnpXbNGUHDFBpRIt1+7767soQOFzhf6sw5E5lt0BCPvuLGizw
+              5dQwOxsU3Nc2otasAOB9wkCP7DG+f/X7nijC0Xv9gGGFGHHWO4mWhzXC4c7/JLEr
+              LiF/WUcbacTB0HUFvYPWt7mPDwEs+5fjEIbNfIyEQJSt1xMNOsAHHsN78x0CgYAv
+              44Y4ycn74hkJYCGWL2UvKlvMuBifpmeD+RUybR8awTiMTzD4rxRUzTQIvaoA39NB
+              dbsj/LpvpzZau4vhVV1nBYdQ1QAUS1HwJBZoTGsNHd9i0h864uaZS5L5SfGDLxtv
+              8GN+2TPAeEykr2FaVWpBt3C5E8KdN/SsLUr7UvTMYQKBgEgenppn2JsbYCmUjWlv
+              7Gora+L7JQwH2DLbQjrkKZVZYrOO8iMO0QR31jy5uQpKnUDZLnE3t7mjg9QXVOIB
+              VkAj0cgEdj/3lTuJGfriUCTdQwFSwjJKeXd6+Wcnreu7JARLkLluxeIRjlrDpTSr
+              rE91Os0bu8YS3+qFbQ2NmIzo
+              -----END PRIVATE KEY-----
+            crt: |
+              -----BEGIN CERTIFICATE-----
+              MIIDxTCCAq2gAwIBAgIJAKGUQu+mYQwzMA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNV
+              BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMQwwCgYDVQQHDANhc2QxITAfBgNV
+              BAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDENMAsGA1UECwwEdGVjaDEVMBMG
+              A1UEAwwMKi5zc2xmb28uY29tMB4XDTE1MDcyMDIzMzQ1NFoXDTE1MDgxOTIzMzQ1
+              NFoweTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxDDAKBgNVBAcM
+              A2FzZDEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMQ0wCwYDVQQL
+              DAR0ZWNoMRUwEwYDVQQDDAwqLnNzbGZvby5jb20wggEiMA0GCSqGSIb3DQEBAQUA
+              A4IBDwAwggEKAoIBAQDE/xm+MDpvOSNwIX9tATbB+qxisfWtcQgo20wIu4EJICJk
+              3DJ56V8yMzG5a0x7SMmk1b2XMuls8FZvAj9NhtsNHW02iMMz8U/cy5H+8z+2dBLc
+              eHynkFse4KV7h7FqLDwKqsbXCCp5sO3csuE43Jo2DVoCVNTDaUtCAMqelwIFHAvJ
+              VLT1OoaNiJD5T8G9r/IOgS0RCeWk0NvHetnYtvwAvxtz+Y4tsSxAwLE+LgQtHdOp
+              I/pdCa5P8SX37NHY/fbu95ESjYyMvybA9TDqziUUx5V5iMDX9UYfOTI764S5aorj
+              fy0Rt9fqlpnqmKRs1qXKosH0Zh555BuxdTfi1cslAgMBAAGjUDBOMB0GA1UdDgQW
+              BBRGl2Y0n1sj6f/APX/e9PSlNhGDRjAfBgNVHSMEGDAWgBRGl2Y0n1sj6f/APX/e
+              9PSlNhGDRjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB8NJnZWmyX
+              g1J7S6YcVxIBoX1d1gzvFn0N6w1L0BWTm+/skHGw0qxJ/gUPkOYFYxlxwekSgxRl
+              aSLl9S8hmLIVI/LZPzvFIGPjV9o/KqYUZuiGCXGDXrGP7fUuBMOdwSC3UN67q/0n
+              h4UdOSPN/zWdCS6VrRvgHK9XA39lWI7EdnXtZFVa+d5wjbVBhHQy6VG1ewxsfENe
+              +W3oPqULjoJQwo3dFx06179SxfK5x2+01DFEfbn1lHVSLgaRwugsK195Vz/LE1AU
+              8g5WFN/5+YJzDt5bypUycUH1Evyv93m1J9FePuP2kqVRx3XhvI4lXUZKaUI34qql
+              x1AtpNEaHJFj
+              -----END CERTIFICATE-----
+            ca: |
+              -----BEGIN CERTIFICATE-----
+              MIIDxTCCAq2gAwIBAgIJAKGUQu+mYQwzMA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNV
+              BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMQwwCgYDVQQHDANhc2QxITAfBgNV
+              BAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDENMAsGA1UECwwEdGVjaDEVMBMG
+              A1UEAwwMKi5zc2xmb28uY29tMB4XDTE1MDcyMDIzMzQ1NFoXDTE1MDgxOTIzMzQ1
+              NFoweTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxDDAKBgNVBAcM
+              A2FzZDEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMQ0wCwYDVQQL
+              DAR0ZWNoMRUwEwYDVQQDDAwqLnNzbGZvby5jb20wggEiMA0GCSqGSIb3DQEBAQUA
+              A4IBDwAwggEKAoIBAQDE/xm+MDpvOSNwIX9tATbB+qxisfWtcQgo20wIu4EJICJk
+              3DJ56V8yMzG5a0x7SMmk1b2XMuls8FZvAj9NhtsNHW02iMMz8U/cy5H+8z+2dBLc
+              eHynkFse4KV7h7FqLDwKqsbXCCp5sO3csuE43Jo2DVoCVNTDaUtCAMqelwIFHAvJ
+              VLT1OoaNiJD5T8G9r/IOgS0RCeWk0NvHetnYtvwAvxtz+Y4tsSxAwLE+LgQtHdOp
+              I/pdCa5P8SX37NHY/fbu95ESjYyMvybA9TDqziUUx5V5iMDX9UYfOTI764S5aorj
+              fy0Rt9fqlpnqmKRs1qXKosH0Zh555BuxdTfi1cslAgMBAAGjUDBOMB0GA1UdDgQW
+              BBRGl2Y0n1sj6f/APX/e9PSlNhGDRjAfBgNVHSMEGDAWgBRGl2Y0n1sj6f/APX/e
+              9PSlNhGDRjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB8NJnZWmyX
+              g1J7S6YcVxIBoX1d1gzvFn0N6w1L0BWTm+/skHGw0qxJ/gUPkOYFYxlxwekSgxRl
+              aSLl9S8hmLIVI/LZPzvFIGPjV9o/KqYUZuiGCXGDXrGP7fUuBMOdwSC3UN67q/0n
+              h4UdOSPN/zWdCS6VrRvgHK9XA39lWI7EdnXtZFVa+d5wjbVBhHQy6VG1ewxsfENe
+              +W3oPqULjoJQwo3dFx06179SxfK5x2+01DFEfbn1lHVSLgaRwugsK195Vz/LE1AU
+              8g5WFN/5+YJzDt5bypUycUH1Evyv93m1J9FePuP2kqVRx3XhvI4lXUZKaUI34qql
+              x1AtpNEaHJFj
+              -----END CERTIFICATE-----
+          http_directives: |
+              return 301 https://www.sslfoo.com;
+
+          https_directives: |
+              access_log off;
+
+    - nginx_cache_dirs:
+        a_cache:
+          prefix: /opt/cache/nginx
+
+    - nginx_config:
+        log_format: |
+          log_format test '$remote_addr - $remote_user [$time_local] '
+            '"$request" $status $body_bytes_sent '
+            '"$http_referer" "$http_user_agent" '
+            '"$http_x_forwarded_for" $request_time';
+
+        caching: |
+          proxy_cache_path
+            {{nginx_cache_dirs.a_cache.prefix}}
+            levels=1:2
+            keys_zone=a_cache:100m
+            inactive=60m;
+
+  roles:
+    - {
+        role: ansible-role-nginx
+      }

--- a/molecule/compiled/molecule.yml
+++ b/molecule/compiled/molecule.yml
@@ -1,0 +1,25 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+lint: |
+  set -e
+  yamllint .
+platforms:
+  - name: vagrant-centos7
+    box: centos/7
+    memory: 512
+    cpus: 2
+  - name: vagrant-ubuntu
+    box: ubuntu/focal64
+    memory: 512
+    cpus: 2
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      stdout_callback: yaml
+      become: yes
+verifier:
+  name: ansible

--- a/molecule/compiled/verify.yml
+++ b/molecule/compiled/verify.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check that nginx responds at the default port
+      uri:
+        url: http://localhost:80/
+        status_code: 404

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,137 @@
+---
+- hosts: all
+  become: yes
+
+  vars:
+    - nginx_context_main: |
+        worker_rlimit_nofile 4096;
+        worker_processes 1;
+    - nginx_no_log: false
+    - nginx_log_symlink_src: /mnt/log/nginx
+    - nginx_disable_vhosts:
+        - default
+    - nginx_vhosts:
+        - server_name: foo.com
+          default_server: true
+          listen_parameters:
+            - deferred
+            - backlog=512
+          access_log: "{{nginx_log_dir}}/othervhosts.log"
+          logrotate_enabled: true
+          server_aliases:
+            - www.foo.bar
+            - baz.foo.bar
+          root: /var/www/foo.com/html
+          log_fmt: test
+
+        - server_name: sslfoo.com
+          server_aliases:
+            - www.sslfoo.bar
+          root: /var/www/sslfoo.com/html
+          ssl_enabled: true
+          certs:
+            key: |
+              -----BEGIN PRIVATE KEY-----
+              MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDE/xm+MDpvOSNw
+              IX9tATbB+qxisfWtcQgo20wIu4EJICJk3DJ56V8yMzG5a0x7SMmk1b2XMuls8FZv
+              Aj9NhtsNHW02iMMz8U/cy5H+8z+2dBLceHynkFse4KV7h7FqLDwKqsbXCCp5sO3c
+              suE43Jo2DVoCVNTDaUtCAMqelwIFHAvJVLT1OoaNiJD5T8G9r/IOgS0RCeWk0NvH
+              etnYtvwAvxtz+Y4tsSxAwLE+LgQtHdOpI/pdCa5P8SX37NHY/fbu95ESjYyMvybA
+              9TDqziUUx5V5iMDX9UYfOTI764S5aorjfy0Rt9fqlpnqmKRs1qXKosH0Zh555Bux
+              dTfi1cslAgMBAAECggEBAJBicNnGu219sY2j36NjOmEee26zBGAk8lgPs0DLPR4V
+              IWBPS+eytoUypIVEMYBCrxhTWGwTcqbX2GHwgbku2CpaoQtRXdEaUvB/e/gjDVWK
+              6bAR1ztxQHf3KxLJN62b0j33QVmlsIwUs6IIsa5dceGgE5KV3oODDxfHQLrP7zkS
+              NeRAiwf4KwdBL71Xka7/PN+DM6TtiIrZeSJTnE/1FjflTkG/noa6mHMS3z/fAMKP
+              9MctD5H+Qu/2LTDPofmH5kAQiV+CE2yGUHtIMvaUfxy7cl8/L9sQQzMPbdNhZQXP
+              LghYjAIFpnkf3nPr0WZtqXzrfGV5HWtO2H3ny4bkT8ECgYEA6Jvxx+L1rWltHMiR
+              7/lwGLA74DIzfQzme89+f+2g2fvImBWPf/aXrcoENHuSKmrTYbsijxQ7XKw+jZQu
+              BSuRKI1l+0jku6tm6l6+U8dKNjksqOJ5oiSklxbzXCj5m2rocAhGVTjkiq2jZ3Zw
+              OG9TCLQAsZ63Jd8Ue1obb/mk8z0CgYEA2M5hIOSsauLfT1FUgHonKcxFuyuZJI3i
+              nXkNkq4u97q8QqFgIWOd4nVwgeeSwUm2B/CpF/pQJxOPIwx+/WebxXsgA+VrMMxm
+              oYe4WXZnTeYMUhUdukpNCXJRJsfQIWYxEzzTEWnwwA3QRPhBQCMqx+9ZWdhzvorS
+              Kg2RGBXKFgkCgYEAnpXbNGUHDFBpRIt1+7767soQOFzhf6sw5E5lt0BCPvuLGizw
+              5dQwOxsU3Nc2otasAOB9wkCP7DG+f/X7nijC0Xv9gGGFGHHWO4mWhzXC4c7/JLEr
+              LiF/WUcbacTB0HUFvYPWt7mPDwEs+5fjEIbNfIyEQJSt1xMNOsAHHsN78x0CgYAv
+              44Y4ycn74hkJYCGWL2UvKlvMuBifpmeD+RUybR8awTiMTzD4rxRUzTQIvaoA39NB
+              dbsj/LpvpzZau4vhVV1nBYdQ1QAUS1HwJBZoTGsNHd9i0h864uaZS5L5SfGDLxtv
+              8GN+2TPAeEykr2FaVWpBt3C5E8KdN/SsLUr7UvTMYQKBgEgenppn2JsbYCmUjWlv
+              7Gora+L7JQwH2DLbQjrkKZVZYrOO8iMO0QR31jy5uQpKnUDZLnE3t7mjg9QXVOIB
+              VkAj0cgEdj/3lTuJGfriUCTdQwFSwjJKeXd6+Wcnreu7JARLkLluxeIRjlrDpTSr
+              rE91Os0bu8YS3+qFbQ2NmIzo
+              -----END PRIVATE KEY-----
+            crt: |
+              -----BEGIN CERTIFICATE-----
+              MIIDxTCCAq2gAwIBAgIJAKGUQu+mYQwzMA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNV
+              BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMQwwCgYDVQQHDANhc2QxITAfBgNV
+              BAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDENMAsGA1UECwwEdGVjaDEVMBMG
+              A1UEAwwMKi5zc2xmb28uY29tMB4XDTE1MDcyMDIzMzQ1NFoXDTE1MDgxOTIzMzQ1
+              NFoweTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxDDAKBgNVBAcM
+              A2FzZDEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMQ0wCwYDVQQL
+              DAR0ZWNoMRUwEwYDVQQDDAwqLnNzbGZvby5jb20wggEiMA0GCSqGSIb3DQEBAQUA
+              A4IBDwAwggEKAoIBAQDE/xm+MDpvOSNwIX9tATbB+qxisfWtcQgo20wIu4EJICJk
+              3DJ56V8yMzG5a0x7SMmk1b2XMuls8FZvAj9NhtsNHW02iMMz8U/cy5H+8z+2dBLc
+              eHynkFse4KV7h7FqLDwKqsbXCCp5sO3csuE43Jo2DVoCVNTDaUtCAMqelwIFHAvJ
+              VLT1OoaNiJD5T8G9r/IOgS0RCeWk0NvHetnYtvwAvxtz+Y4tsSxAwLE+LgQtHdOp
+              I/pdCa5P8SX37NHY/fbu95ESjYyMvybA9TDqziUUx5V5iMDX9UYfOTI764S5aorj
+              fy0Rt9fqlpnqmKRs1qXKosH0Zh555BuxdTfi1cslAgMBAAGjUDBOMB0GA1UdDgQW
+              BBRGl2Y0n1sj6f/APX/e9PSlNhGDRjAfBgNVHSMEGDAWgBRGl2Y0n1sj6f/APX/e
+              9PSlNhGDRjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB8NJnZWmyX
+              g1J7S6YcVxIBoX1d1gzvFn0N6w1L0BWTm+/skHGw0qxJ/gUPkOYFYxlxwekSgxRl
+              aSLl9S8hmLIVI/LZPzvFIGPjV9o/KqYUZuiGCXGDXrGP7fUuBMOdwSC3UN67q/0n
+              h4UdOSPN/zWdCS6VrRvgHK9XA39lWI7EdnXtZFVa+d5wjbVBhHQy6VG1ewxsfENe
+              +W3oPqULjoJQwo3dFx06179SxfK5x2+01DFEfbn1lHVSLgaRwugsK195Vz/LE1AU
+              8g5WFN/5+YJzDt5bypUycUH1Evyv93m1J9FePuP2kqVRx3XhvI4lXUZKaUI34qql
+              x1AtpNEaHJFj
+              -----END CERTIFICATE-----
+            ca: |
+              -----BEGIN CERTIFICATE-----
+              MIIDxTCCAq2gAwIBAgIJAKGUQu+mYQwzMA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNV
+              BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMQwwCgYDVQQHDANhc2QxITAfBgNV
+              BAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDENMAsGA1UECwwEdGVjaDEVMBMG
+              A1UEAwwMKi5zc2xmb28uY29tMB4XDTE1MDcyMDIzMzQ1NFoXDTE1MDgxOTIzMzQ1
+              NFoweTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxDDAKBgNVBAcM
+              A2FzZDEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMQ0wCwYDVQQL
+              DAR0ZWNoMRUwEwYDVQQDDAwqLnNzbGZvby5jb20wggEiMA0GCSqGSIb3DQEBAQUA
+              A4IBDwAwggEKAoIBAQDE/xm+MDpvOSNwIX9tATbB+qxisfWtcQgo20wIu4EJICJk
+              3DJ56V8yMzG5a0x7SMmk1b2XMuls8FZvAj9NhtsNHW02iMMz8U/cy5H+8z+2dBLc
+              eHynkFse4KV7h7FqLDwKqsbXCCp5sO3csuE43Jo2DVoCVNTDaUtCAMqelwIFHAvJ
+              VLT1OoaNiJD5T8G9r/IOgS0RCeWk0NvHetnYtvwAvxtz+Y4tsSxAwLE+LgQtHdOp
+              I/pdCa5P8SX37NHY/fbu95ESjYyMvybA9TDqziUUx5V5iMDX9UYfOTI764S5aorj
+              fy0Rt9fqlpnqmKRs1qXKosH0Zh555BuxdTfi1cslAgMBAAGjUDBOMB0GA1UdDgQW
+              BBRGl2Y0n1sj6f/APX/e9PSlNhGDRjAfBgNVHSMEGDAWgBRGl2Y0n1sj6f/APX/e
+              9PSlNhGDRjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB8NJnZWmyX
+              g1J7S6YcVxIBoX1d1gzvFn0N6w1L0BWTm+/skHGw0qxJ/gUPkOYFYxlxwekSgxRl
+              aSLl9S8hmLIVI/LZPzvFIGPjV9o/KqYUZuiGCXGDXrGP7fUuBMOdwSC3UN67q/0n
+              h4UdOSPN/zWdCS6VrRvgHK9XA39lWI7EdnXtZFVa+d5wjbVBhHQy6VG1ewxsfENe
+              +W3oPqULjoJQwo3dFx06179SxfK5x2+01DFEfbn1lHVSLgaRwugsK195Vz/LE1AU
+              8g5WFN/5+YJzDt5bypUycUH1Evyv93m1J9FePuP2kqVRx3XhvI4lXUZKaUI34qql
+              x1AtpNEaHJFj
+              -----END CERTIFICATE-----
+          http_directives: |
+              return 301 https://www.sslfoo.com;
+
+          https_directives: |
+              access_log off;
+
+    - nginx_cache_dirs:
+        a_cache:
+          prefix: /opt/cache/nginx
+
+    - nginx_config:
+        log_format: |
+          log_format test '$remote_addr - $remote_user [$time_local] '
+            '"$request" $status $body_bytes_sent '
+            '"$http_referer" "$http_user_agent" '
+            '"$http_x_forwarded_for" $request_time';
+
+        caching: |
+          proxy_cache_path
+            {{nginx_cache_dirs.a_cache.prefix}}
+            levels=1:2
+            keys_zone=a_cache:100m
+            inactive=60m;
+
+  roles:
+    - {
+        role: ansible-role-nginx
+      }

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,25 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+lint: |
+  set -e
+  yamllint .
+platforms:
+  - name: vagrant-centos7
+    box: centos/7
+    memory: 512
+    cpus: 2
+  - name: vagrant-ubuntu
+    box: ubuntu/focal64
+    memory: 512
+    cpus: 2
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      stdout_callback: yaml
+      become: yes
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check that nginx responds at the default port
+      uri:
+        url: http://localhost:80/
+        status_code: 404

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,7 +7,7 @@
     owner: "root"
     group: "{{nginx_group}}"
     mode:  "0644"
-  notify: nginx restart
+  notify: nginx reload
 
 
 - name: Nginx configuration includes
@@ -18,7 +18,7 @@
     group: "{{nginx_group}}"
     mode:  "0644"
   with_dict: "{{nginx_config}}"
-  notify: nginx restart
+  notify: nginx reload
 
 
 - name: Nginx OS family config (Debian)

--- a/tasks/config/RedHat.yml
+++ b/tasks/config/RedHat.yml
@@ -12,6 +12,6 @@
     backrefs: yes
     line:     '\1;'
   when: default_vh.stat.exists
-  notify: nginx restart
+  notify: nginx reload
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/dirs.yml
+++ b/tasks/dirs.yml
@@ -77,5 +77,20 @@
     group: "{{nginx_group}}"
   when: nginx_log_symlink_src != False
 
+# SELinux Policies must be adjusted when using nginx_log_symlink_src, to ensure the
+# appropriate context is provided for the files created there.
+# TODO: ensure SELinux policies are properly setup when using compiled nginx.
+
+- name: Check SELinux status
+  shell: "getenforce | grep 'Enforcing'"
+  failed_when: false
+  register: _nginx_selinux_enforcing # rc == 0 when SELinux is enabled and managed
+
+- include: dirs_selinux.yml
+  when:
+    - _nginx_selinux_enforcing.rc == 0
+    - nginx_install_repo
+    - _nginx_log_dir.stat.isdir is defined
+    - nginx_log_symlink_src != False
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/dirs_selinux.yml
+++ b/tasks/dirs_selinux.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Nginx Log directory check if SELinux context information is present
+  shell: "semanage fcontext --list -C | grep -E '^{{ nginx_log_symlink_src }} = {{ nginx_log_dir }}'"
+  failed_when: false
+  register: _nginx_log_dir_fcontext
+
+- name: Nginx Log directory add SELinux context information
+  command: >
+    semanage fcontext -a -e {{ nginx_log_dir }} {{ nginx_log_symlink_src }}
+  when:
+    - _nginx_log_dir_fcontext.rc != 0
+
+- name: Nginx Log directory ensure SELinux context is correct in new dir
+  command: "restorecon -R {{ nginx_log_symlink_src }}"
+
+# Restore the SELinux context provided by the nginx package after the forced symlink
+# creation in "Nginx Log directory symlink" breaks it.
+- name: Nginx Log directory ensure SELinux context is correct in default location (symlink)
+  command: "restorecon {{ nginx_log_dir }}"

--- a/tasks/install/compiled_lua.yml
+++ b/tasks/install/compiled_lua.yml
@@ -22,4 +22,4 @@
 
 - name: Install additional lua rocks
   command: "/usr/local/bin/luarocks install {{item.name}} {{item.version}}"
-  loop: "{{nginx_lua_rocks}}"
+  with_items: "{{ nginx_lua_rocks }}"

--- a/tasks/install/compiled_luajit.yml
+++ b/tasks/install/compiled_luajit.yml
@@ -3,6 +3,12 @@
 # Compile and install nginx using source code
 #
 
+- name: Install dependencies for LuaJIT compilation
+  package:
+    name: "{{ nginx_compiled_luajit_packages }}"
+    state: "present"
+    update_cache: true
+
 - name: Download LuaJIT sources
   git:
     repo: "{{nginx_luajit_repository}}"
@@ -10,12 +16,6 @@
     version: "{{nginx_luajit_git_version}}"
     accept_hostkey: yes
     force: yes
-
-- name: Install dependencies for LuaJIT compilation
-  package:
-    name: "{{ nginx_compiled_luajit_packages }}"
-    state: "present"
-    update_cache: true
 
 - name: Build LuaJIT
   make:

--- a/tasks/install/compiled_luajit.yml
+++ b/tasks/install/compiled_luajit.yml
@@ -11,6 +11,12 @@
     accept_hostkey: yes
     force: yes
 
+- name: Install dependencies for LuaJIT compilation
+  package:
+    name: "{{ nginx_compiled_luajit_packages }}"
+    state: "present"
+    update_cache: true
+
 - name: Build LuaJIT
   make:
     chdir: /usr/local/src/luajit.git

--- a/tasks/install/compiled_nginx.yml
+++ b/tasks/install/compiled_nginx.yml
@@ -10,8 +10,9 @@
 
 - name: Install dependencies for compilation
   package:
-    name:  "{{nginx_compilation_packages}}"
+    name: "{{nginx_compilation_packages}}"
     state: "present"
+    update_cache: true
 
 - name: Install extra dependencies for compilation
   package:
@@ -64,5 +65,28 @@
     owner: root
     group: root
     mode: "0755"
+  when: ansible_service_mgr != "systemd"
 
+- name: Install systemd unit file
+  template:
+    src: etc/systemd/system/nginx.service
+    dest: /etc/systemd/system/nginx.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: ansible_service_mgr == "systemd"
+  register: _nginx_systemd_unit_file
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+  when: _nginx_systemd_unit_file.changed and ansible_service_mgr == "systemd"
+
+- name: Nginx Temp directories
+  file:
+    state: directory
+    dest: /var/lib/nginx/tmp/  # See defaults/main.yml
+    owner: "{{ nginx_user }}"
+    group: "{{ nginx_group }}"
+    mode: "0750"
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/compiled_nginx.yml
+++ b/tasks/install/compiled_nginx.yml
@@ -54,6 +54,7 @@
   make:
     chdir: /usr/local/src/nginx-{{nginx_version}}
     target: install
+  notify: nginx restart
   become: true
 
 - name: Install init script

--- a/tasks/install/compiled_nginx.yml
+++ b/tasks/install/compiled_nginx.yml
@@ -51,12 +51,32 @@
   make:
     chdir: /usr/local/src/nginx-{{nginx_version}}
 
+- name: Stat nginx compiled binary
+  stat:
+    checksum_algorithm: sha256
+    get_checksum: true
+    # This path is probably dependent on the nginx version.
+    path: /usr/local/src/nginx-{{ nginx_version }}/objs/nginx
+  register: _nginx_src_compiled_binary_stat
+
+- name: Stat nginx installed binary
+  stat:
+    checksum_algorithm: sha256
+    get_checksum: true
+    path: "{{ nginx_bin }}"
+  register: _nginx_src_installed_binary_stat
+  failed_when: false  # The file doesn't exist when this is first run
+
 - name: Install source code
   make:
     chdir: /usr/local/src/nginx-{{nginx_version}}
     target: install
   notify: nginx restart
   become: true
+  when: >
+    not _nginx_src_installed_binary_stat.stat.exists or
+    (_nginx_src_installed_binary_stat.stat.checksum !=
+      _nginx_src_compiled_binary_stat.stat.checksum)
 
 - name: Install init script
   template:

--- a/tasks/install/repository_nginx.yml
+++ b/tasks/install/repository_nginx.yml
@@ -3,9 +3,18 @@
 # Install required packages
 #
 
-- name: Install Nginx using repositories
+- name: Install Nginx using repositories (other)
   package:
     name:  "{{nginx_repo_packages}}"
     state: "present"
+    update_cache: yes
+  when: ansible_os_family != "RedHat"
+
+- name: Install Nginx using repositories (RedHat)
+  yum:
+    name:  "{{ nginx_repo_packages }}"
+    state: "present"
+    enablerepo: "epel"
+  when: ansible_os_family == "RedHat"
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
   include_vars: "{{ansible_architecture}}.yml"
   tags: always
 
+- include: prepare.yml
+  tags: nginx_prepare
+
 - include: install.yml
   tags: nginx_install
 

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -4,4 +4,14 @@
   yum:
     name: "epel-release"
     state: "present"
-  when: ansible_os_family == "RedHat"
+  when: >
+    ansible_os_family == "RedHat" and not
+      (ansible_distribution == 'Amazon' and ansible_distribution_version == '2')
+
+- name: Add EPEL repository (Amazon Linux 2)
+  shell: >
+    set -o pipefail
+
+    amazon-linux-extras list | grep -Eq 'epel\s+enabled' ||
+    amazon-linux-extras install epel -y
+  when: ansible_distribution == 'Amazon' and ansible_distribution_version == '2'

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -4,9 +4,9 @@
   yum:
     name: "epel-release"
     state: "present"
-  when: >
-    ansible_os_family == "RedHat" and not
-      (ansible_distribution == 'Amazon' and ansible_distribution_version == '2')
+  when:
+    - ansible_os_family == "RedHat"
+    - not (ansible_distribution == 'Amazon' and ansible_distribution_version == '2')
 
 - name: Add EPEL repository (Amazon Linux 2)
   shell: >
@@ -14,4 +14,6 @@
 
     amazon-linux-extras list | grep -Eq 'epel\s+enabled' ||
     amazon-linux-extras install epel -y
-  when: ansible_distribution == 'Amazon' and ansible_distribution_version == '2'
+  when:
+    - ansible_distribution == 'Amazon'
+    - ansible_distribution_version == '2'

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Add EPEL repository (RedHat)
+  yum:
+    name: "epel-release"
+    state: "present"
+  when: ansible_os_family == "RedHat"

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -12,7 +12,7 @@
     mode:    "0640"
   when: (item.ssl_enabled is defined) and (item.ssl_enabled)
   with_items: "{{nginx_vhosts}}"
-  notify: nginx restart
+  notify: nginx reload
   no_log: true
 
 - name: SSL PEM
@@ -24,7 +24,7 @@
     mode:  "0640"
   when: (item.ssl_enabled is defined) and (item.ssl_enabled)
   with_items: "{{nginx_vhosts}}"
-  notify: nginx restart
+  notify: nginx reload
   no_log: true
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -20,7 +20,7 @@
     mode:  "0755"
   when: (item.create_root is defined) and (item.create_root) and (item.root is defined) and (item.root)
   with_items: "{{nginx_vhosts}}"
-  notify: nginx restart
+  notify: nginx reload
   no_log: true
 
 
@@ -32,7 +32,7 @@
     group: "root"
     mode:  "0644"
   with_items: "{{nginx_vhosts}}"
-  notify: nginx restart
+  notify: nginx reload
   no_log: true
 
 
@@ -42,7 +42,7 @@
     dest:  "{{nginx_sites_enabled}}/{{item.server_name}}.conf"
     state: link
   with_items: "{{nginx_vhosts}}"
-  notify: nginx restart
+  notify: nginx reload
   no_log: true
 
 
@@ -51,7 +51,7 @@
     state: absent
     dest:  "{{nginx_sites_enabled}}/{{item}}"
   with_items: "{{nginx_disable_vhosts}}"
-  notify: nginx restart
+  notify: nginx reload
 
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/templates/etc/systemd/system/nginx.service
+++ b/templates/etc/systemd/system/nginx.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=The nginx HTTP and reverse proxy server
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile={{ nginx_pid_file }}
+# Nginx will fail to start if {{ nginx_pid_file }} already exists but has the wrong
+# SELinux context. This might happen when running `nginx -t` from the cmdline.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1268621
+ExecStartPre=/usr/bin/rm -f {{ nginx_pid_file }}
+ExecStartPre=/usr/local/sbin/nginx -t
+ExecStart=/usr/local/sbin/nginx
+ExecReload=/bin/kill -s HUP $MAINPID
+KillSignal=SIGQUIT
+TimeoutStopSec=5
+KillMode=process
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,16 +5,37 @@ nginx_group: www-data
 
 nginx_repo_packages:
   - nginx
-  - nginx-full
   - nginx-common
   - openssl
+  - policycoreutils-python-utils
 
-nginx_compilation_packages: []
-nginx_compilation_arch_packages: []
+nginx_compilation_packages:
+  - gcc
+  - make
+  - libpcre3-dev
+  - libssl-dev
+  - zlib1g-dev
+  - unzip
 
-nginx_compiled_luajit_git: false
-nginx_configure_environ: {}
-nginx_lua_rocks_configure_args: ""
+nginx_compilation_arch_packages:
+  - lua5.1
+  - libluajit-5.1-dev
+
+nginx_version: 1.18.0 # default version fails to compile (glibc issue -- error: struct
+                      # crypt_data has no member named current_salt)
+
+# For nginx to compile, given the default configuration options provided, these settings
+# are required.
+nginx_compiled_luajit_git: true
+nginx_configure_environ:
+  LUAJIT_LIB: /usr/local/luajit/lib
+  LUAJIT_INC: /usr/local/luajit/include/luajit-2.1
+
+nginx_compiled_luajit_packages:
+  - gcc
+  - make
+
+nginx_lua_rocks_configure_args: --with-lua-include=/usr/local/luajit/include/luajit-2.1
 
 nginx_pid_file: /run/nginx.pid
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,6 +5,7 @@ nginx_group: nginx
 
 nginx_repo_packages:
   - nginx
+  - policycoreutils-python
 
 nginx_compilation_packages:
   - gcc
@@ -14,11 +15,16 @@ nginx_compilation_packages:
   - openssl-devel
   - pcre-devel
   - zlib-devel
+  - unzip
 
 nginx_compilation_arch_packages:
   - luajit-devel
 
 nginx_compiled_luajit_git: false
+nginx_compiled_luajit_packages:
+  - gcc
+  - make
+
 nginx_configure_environ: {}
 nginx_lua_rocks_configure_args: --with-lua-include=/usr/include/luajit-2.0
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -22,6 +22,7 @@ nginx_compilation_arch_packages:
 
 nginx_compiled_luajit_git: false
 nginx_compiled_luajit_packages:
+  - git  # amazon-linux-2 in aarch64 doesn't come with git installed by default
   - gcc
   - make
 

--- a/vars/aarch64.yml
+++ b/vars/aarch64.yml
@@ -7,4 +7,3 @@ nginx_configure_environ:
 nginx_lua_rocks_configure_args: --with-lua=/usr/local/luajit
 
 nginx_arch_flags: "-mtune=generic"
-


### PR DESCRIPTION
It turned out to be a much bigger change than I originally intended, because before making changes I wanted to make sure that tests could be easily run using Molecule.

Naturally, for the role to work in the two main platforms I expected (Ubuntu 20.04 and Centos7, the most similar OSs to what we usually run in the cloud), some changes had to be made.

Fortunately you can now just test the two basic scenarios by running either

```
$ molecule create && \
molecule converge && \
molecule verify
```

or

```
$ molecule create --scenario-name=compiled && \
molecule converge --scenario-name=compiled && \
molecule verify --scenario-name=compiled
```

(assuming you've installed `molecule` and `molecule-vagrant`). This lets us test the following scenarios per OS/arch:

| Scenario/OS | Ubuntu 20.04 | Centos7 |
| -- | -- | -- |
| **packages** | amd64 | amd64 |
| **source** | amd64 | amd64 |

To make the review a little bit easier, you can take a look at individual commits at a time. Here's a simple breakdown of the changes, so you can review most of them in a more "atomic" way:

- [updated test ubuntu VM, fixed centos7 tests](https://github.com/jampp/ansible-role-nginx/commit/837791a141d8250d203f3054a7f4e95964202c57): Replaced testing Ubuntu Xenial for Focal (removing the oldest in favor of the newest). Also in this commit I changed the way pip was installed there, to ensure that it's compatible with Python 2.7, which is what we use to run ansible.
- [remove old distributions from test Vagranfile ](https://github.com/jampp/ansible-role-nginx/commit/76ac324eb6440875c5578f4a158177484bc2fb90): I removed all the other old distros to only maintain the latest CentOS and the latest Ubuntu.
- [signal reload handler when configuration changes ](https://github.com/jampp/ansible-role-nginx/commit/180eeb399b90962e760ca39d6fa704081c9fbaf9): Added a `reload` handler which can be used after [any kind of configuration changes](https://nginx.org/en/docs/control.html?_ga=2.222185944.1720979233.1617119973-1093731195.1614347603), unless you want to upgrade the executable process on the fly, which requires a more sophisticated approach (so a `restart` can be used in that case.)
- [add restart handler after changing compiled nginx](https://github.com/jampp/ansible-role-nginx/commit/582a0438a978e87d3f362177972b21d71f6a772e): This is the exception mentioned above, where we just do a restart if there was a change in the nginx binary.
- [add molecule testing and fix bugs](https://github.com/jampp/ansible-role-nginx/commit/e375df02788141db27ea86a8d404fa8b6430c895): This is the big change, sorry. Here we add the general configuration for Molecule, to support the test matrix described above, and we made any necessary changes to the role so everything works. A more detailed discussion of the changes done here is mentioned below (see "additional CHANGES").
- [don't re-install compiled nginx if it didn't change](https://github.com/jampp/ansible-role-nginx/commit/25b533892c19e833b522c9b3e2ac56b59ae0b7fe): Here we add a little bit of detection logic to ensure we only restart the nginx service when the nginx binary has changed (otherwise the handler is invoked in every execution). Please note that this doesn't prevent the `./configure ... && make` process, unfortunately, so an incremental run of the playbook is unnecessarily slow. Perhaps we could improve this in the future.
- [ensure nginx compiles in Amazon Linux 2](https://github.com/jampp/ansible-role-nginx/commit/e373a76293bdf1730f251120a45a378460ec8e49): When I tested everything in EC2 (just to make sure that this worked in Amazon Linux 2, since it's not strictly the same as CentOS) I realized I had a couple of issues: For one, I don't know why `git` is not on by default in Graviton2 instances of Amazon Linux 2, which is why I added it to `nginx_compiled_luajit_packages` and put it before the clone of the nginx source code. The other thing was to enable the EPEL repos, which are not on by default.

## additional CHANGES

e375df02788141db27ea86a8d404fa8b6430c895 is a little bit hard to explain in just one line, so there's a specific section for it here. What's important to know is:

- The `molecule/{default,compiled}/converge.yml` fires are **heavily** inspired in `tests/test_vagrant.yml`. I'll make a note to try to find a better way in Molecule to create similar scenarios without duplicating that much code.
- CentOS 7 has SELinux enabled by default (I really don't know why Amazon Linux 2 does not), so I had to add `tasks/dirs_selinux.yml` to handle the proper setup of tags for the "custom" log directory that the role permits. I could have just added a `pre_task` in the manifest disabling SELinux, but that's just not a good practice, especially considering how low effort was to make it work here.
- I added the `nginx_compiled_luajit_packages` variable to list the packages needed to compile luajit (otherwise you'd get errors since at the stage that should run you might not have neither `gcc` nor `make` available.)
- I added a systemd `nginx.service` unit file for compiled nginx (necessary when running systemd enabled distributions like Centos7)

TODO:
- ensure all the scenarios specified in `tests/` are easily runable with Molecule without requiring that much code duplication.
- Properly tag nginx when it's built from source so it runs with SELinux constraints, as it does when installed from RPM packages.
- Ensure the role is `ansible-lint` compliant. I might do it in a separate PR soon, just to prevent adding much more noise to this one, which is already a long change.