### PR TITLE
DEVOPS-5068: Use custom OpenSSL version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ nginx_pid_file: /var/run/nginx.pid;
 
 # Variables to control compilation sources
 nginx_version: 1.13.12
-nginx_openssl_version: 1.0.2
+nginx_openssl_version: 1.0
 nginx_devel_kit_version: 0.3.0
 nginx_lua_rocks_version: 3.0.4
 nginx_lua_module_version: 0.10.14

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ nginx_pid_file: /var/run/nginx.pid;
 
 # Variables to control compilation sources
 nginx_version: 1.13.12
+nginx_openssl_version: 1.0.2
 nginx_devel_kit_version: 0.3.0
 nginx_lua_rocks_version: 3.0.4
 nginx_lua_module_version: 0.10.14

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,12 +7,17 @@ nginx_repo_packages:
   - nginx
   - policycoreutils-python
 
+nginx_openssl_packages:
+  1.0.2: openssl
+  1.1.1: openssl11
+
 nginx_compilation_packages:
   - gcc
   - make
   - git
   - pkgconfig
-  - openssl-devel
+  - "{{ nginx_openssl_packages[nginx_openssl_version] }}"
+  - "{{ nginx_openssl_packages[nginx_openssl_version] }}-devel"
   - pcre-devel
   - zlib-devel
   - unzip

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,8 +8,8 @@ nginx_repo_packages:
   - policycoreutils-python
 
 nginx_openssl_packages:
-  1.0.2: openssl
-  1.1.1: openssl11
+  1.0: openssl
+  1.1: openssl11
 
 nginx_compilation_packages:
   - gcc


### PR DESCRIPTION
With this change, we will be able to choose which version of OpenSSL NGINX will use during its compilation. This only applies to RedHat, Debian systems already come with OpenSSL 1.1.1 by default